### PR TITLE
Fix #7: Add localStorage persistence to Counter

### DIFF
--- a/src/hooks/useCounter.ts
+++ b/src/hooks/useCounter.ts
@@ -1,7 +1,16 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect } from 'react';
+
+const STORAGE_KEY = 'counter-value';
 
 export function useCounter(initialValue = 0) {
-  const [count, setCount] = useState(initialValue);
+  const [count, setCount] = useState(() => {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    return stored !== null ? Number(stored) : initialValue;
+  });
+
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, String(count));
+  }, [count]);
 
   const increment = useCallback(() => {
     setCount((c) => c + 1);


### PR DESCRIPTION
## Summary

Automated fix for #7

## Original Issue

## What should happen

Counter value should persist across page refreshes using localStorage.

## Acceptance criteria

- [ ] Save count to localStorage on every change
- [ ] Load count from localStorage on component mount
- [ ] Use a unique key like 'counter-value'
- [ ] Handle case where localStorage is empty (use default)

## Technical hints

- useEffect for saving
- useState initializer function for loading
- localStorage.getItem/setItem

---
🤖 Generated by automated-coding pipeline
